### PR TITLE
Bump upper bounds

### DIFF
--- a/distributed-process-systest.cabal
+++ b/distributed-process-systest.cabal
@@ -21,7 +21,7 @@ library
                      distributed-static,
                      HUnit >= 1.2 && < 1.7,
                      network-transport >= 0.4.1.0 && < 0.6,
-                     network >= 2.5 && < 2.7,
+                     network >= 2.5,
                      random >= 1.0 && < 1.2,
                      rematch >= 0.1.2.1,
                      test-framework >= 0.6 && < 0.9,

--- a/distributed-process-systest.cabal
+++ b/distributed-process-systest.cabal
@@ -1,5 +1,5 @@
 name:          distributed-process-systest
-version:       0.1.0
+version:       0.2.0
 synopsis:      Testing Frameworks and Capabilities for programs built on Cloud Haskell
 homepage:      http://github.com/haskell-distributed/distributed-process-systest
 license:       BSD3
@@ -14,13 +14,13 @@ cabal-version: >=1.8
 library
   exposed-modules:   Control.Distributed.Process.SysTest.Utils
   Build-Depends:     base >= 4.4 && < 5,
-                     ansi-terminal >= 0.5 && < 0.7,
-                     binary >= 0.5 && < 0.8,
+                     ansi-terminal >= 0.8 && < 0.9,
+                     binary >= 0.8 && < 0.9,
                      bytestring >= 0.9 && < 0.11,
-                     distributed-process >= 0.6.0 && < 0.7,
+                     distributed-process >= 0.6.0 && < 0.8,
                      distributed-static,
-                     HUnit >= 1.2 && < 1.4,
-                     network-transport >= 0.4.1.0 && < 0.5,
+                     HUnit >= 1.2 && < 1.7,
+                     network-transport >= 0.4.1.0 && < 0.6,
                      network >= 2.5 && < 2.7,
                      random >= 1.0 && < 1.2,
                      rematch >= 0.1.2.1,

--- a/src/Control/Distributed/Process/SysTest/Utils.hs
+++ b/src/Control/Distributed/Process/SysTest/Utils.hs
@@ -81,7 +81,7 @@ import Control.Exception (AsyncException(ThreadKilled), SomeException)
 import Control.Monad (forever)
 import Control.Monad.STM (atomically)
 import Control.Rematch hiding (match)
-import Control.Rematch.Run
+import Control.Rematch.Run 
 import Data.Binary
 import Data.Typeable (Typeable)
 

--- a/src/Control/Distributed/Process/SysTest/Utils.hs
+++ b/src/Control/Distributed/Process/SysTest/Utils.hs
@@ -81,7 +81,7 @@ import Control.Exception (AsyncException(ThreadKilled), SomeException)
 import Control.Monad (forever)
 import Control.Monad.STM (atomically)
 import Control.Rematch hiding (match)
-import Control.Rematch.Run 
+import Control.Rematch.Run
 import Data.Binary
 import Data.Typeable (Typeable)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-03-02
+resolver: lts-11.7
 packages:
 - .
 - location:
@@ -15,6 +15,6 @@ packages:
     commit: 7542b749c668d08eea34d65556b889f6ca2e8f2e
 
 extra-deps:
-- network-transport-tcp-0.4.2
+- network-transport-tcp-0.5.1
 - rematch-0.2.0.0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,6 +15,6 @@ packages:
     commit: 7542b749c668d08eea34d65556b889f6ca2e8f2e
 
 extra-deps:
-- network-transport-tcp-0.5.1
+- network-transport-tcp-0.4.2
 - rematch-0.2.0.0
 


### PR DESCRIPTION
Loosens the upper bound constraints so this package builds against newer LTS resolvers and latest version of the unix libraries.